### PR TITLE
Allow arbitrary properties in `MessageOptions` interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ declare module 'ember-cli-flash/services/flash-messages' {
     extendedTimeout: number;
     destroyOnClick: boolean;
     onDestroy: () => void;
+    [key: string]: unknown;
   }
   
   export interface CustomMessageInfo extends Partial<MessageOptions> {


### PR DESCRIPTION
- Fixes #381
- [Spec](https://github.com/adopted-ember-addons/ember-cli-flash#arbitrary-options) allows for custom properties to be passed to flash messages
- Isn't possible with the current TS declarations