### PR TITLE
fix(types): add typesVersions map

### DIFF
--- a/ember-cli-flash/package.json
+++ b/ember-cli-flash/package.json
@@ -41,6 +41,13 @@
     },
     "./addon-main.js": "./addon-main.cjs"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./declarations/*.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "rollup --config",
     "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",


### PR DESCRIPTION
To allow consumers who are still on `"moduleResolution": "node"` in their TS config (i.e. where TS does not use `exports`) to resolve the types correctly.